### PR TITLE
Add rate limiting middleware and cache expiry

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	defaultCacheSize = 1000 << 20 // 1000 MB cache
-	defaultExpiry    = 0          // No expiry
-	stringSeparator  = "<>"       // Assuming the separator wont be used in any case.
+	defaultCacheSize = 1000 << 20  // 1000 MB cache
+	defaultExpiry    = 120 * 3600  // 120 hours cache expiry
+	stringSeparator  = "<>"        // Assuming the separator wont be used in any case.
 )
 
 // Cache objects.

--- a/server.go
+++ b/server.go
@@ -88,6 +88,9 @@ func initHandlers(app *App, enableInternalApis bool) *echo.Echo {
 		// ContentSecurityPolicy: "default-src 'self'",
 	}))
 
+	// rate limit requests per second (prevent handler exhaustion)
+	e.Use(middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(20)))
+
 	return e
 }
 


### PR DESCRIPTION
Preventing DoS attacks would be ideal with a rate limiting middleware because the issue seems to be handler exhaustion and only reproducible with a fairly long input. This PR just utilizes the `echo`'s default [rate limiter middleware](https://echo.labstack.com/middleware/rate-limiter/) with limit set to `20 requests/sec` which is pretty high, I guess a little leeway would be good. (300 WPM Input -> 5 requests per second * 4).

**Here is the before and after with a simulated DoS:**

![Screenshot from 2022-08-13 07-58-46](https://user-images.githubusercontent.com/26198477/184465140-3cd392e8-aea1-4a83-94a9-2a2ea143cbe4.png)
<p align="center">
<em>No socket errors and the Non-2XX responses are <code>HTTP 429 Too Many Requests</code>.</em>
</p>

Also https://github.com/varnamproject/varnamd-govarnam/pull/2#issuecomment-1024882222 didn't work cus `int(time.Hour * 120)` gives `432000000000000`. The correct conversion would be `int((time.Hour * 120).Seconds())` but that can't be initialized as a constant hence fixed that with just `120 * 3600`.

Please let me know if this needs any changes! :raised_hands: