### PR TITLE
WIP: Add support for Docker containerisation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,11 @@ COPY --from=build /usr/local/include/libgovarnam.h /usr/local/include/
 COPY --from=build /usr/local/lib/pkgconfig/govarnam.pc /usr/local/lib/pkgconfig/
 
 # Binaries.
-RUN mkdir -p /govarnam/ui
+RUN mkdir -p /varnamd/ui
 COPY --from=build /app/govarnam/varnamcli /usr/local/bin/
-COPY --from=build /app/varnamd-govarnam/varnamd-govarnam /usr/local/bin/
-COPY --from=build /app/varnamd-govarnam/ui /govarnam/ui/
+COPY --from=build /app/varnamd-govarnam/varnamd-govarnam /usr/local/bin/varnamd
+COPY --from=build /app/varnamd-govarnam/ui /varnamd/ui/
+COPY --from=build /app/varnamd-govarnam/config.toml /varnamd/
 
 # Setup the deps.
 ENV LD_LIBRARY_PATH=/usr/local/lib
@@ -58,6 +59,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends libc-dev sqlite
 
 EXPOSE 8123
 
-WORKDIR /govarnam
-ENTRYPOINT ["/usr/local/bin/varnamd-govarnam"]
-CMD ["--config", "/govarnam/config.toml"]
+WORKDIR /varnamd
+ENTRYPOINT ["/usr/local/bin/varnamd"]
+CMD ["--config", "/varnamd/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,63 @@
-FROM alpine:3.2
-MAINTAINER Navaneeth K N <navaneethkn@gmail.com>
+# This is a multi-stage Docker build that uses the golang:1.21-bullseye image to
+# a) To compile govarnam the shared .so lib and the cli bin
+# b) To compile varnamd-govarnam HTTP server that depends on the lib
+# c) To copy the results into a debian:bullseye-slim image with glibc
 
-# System upgrades and useful utilities
-RUN apk update && apk upgrade
-RUN apk add curl wget bash build-base gcc
-RUN apk add cmake cmake-doc
+###### Build stage
+FROM golang:1.21-bullseye AS build
 
-# Go for compiling varnamd
-RUN wget https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.7.3.linux-amd64.tar.gz
-RUN rm go1.7.3.linux-amd64.tar.gz
-ENV PATH="/usr/local/go/bin:${PATH}"
-ENV GOPATH="${HOME}/gopath"
+WORKDIR /app
 
-# making the go path
-RUN mkdir "${HOME}/gopath"
+# Install dependencies for git and other utilities
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libc-dev gcc git pkg-config sqlite3 && \
+    rm -rf /var/lib/apt/lists/*
 
-# Installing libvarnam
-RUN wget http://download.savannah.gnu.org/releases/varnamproject/libvarnam/source/libvarnam-3.2.5.tar.gz && \
-		tar -xvzf libvarnam-3.2.5.tar.gz && \
-		cd libvarnam-3.2.5 && \
-		cmake . && make && make install
+# Download and compile the shared libgovarnam.so lib
+RUN git clone https://github.com/varnamproject/govarnam.git
+RUN cd govarnam && go build -tags "fts5" -buildmode=c-shared -o libgovarnam.so
 
-# For making go working with alpine muscl
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+# Install the lib.
+RUN mkdir -p /usr/local/include /usr/local/lib/pkgconfig
+RUN cp govarnam/libgovarnam.so /usr/local/lib/ \
+    && cp -R govarnam/c-shared* /usr/local/include/ \
+    && cp govarnam/libgovarnam.h /usr/local/include/ \
+    && sed "s#@INSTALL_PREFIX@#/usr/local#g" govarnam/govarnam.pc.in > /usr/local/lib/pkgconfig/govarnam.pc
 
-RUN apk add git
-ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
-RUN go get github.com/varnamproject/varnamd
+# Build varnamcli.
+RUN cd govarnam && go build -o varnamcli -ldflags "-s -w" ./cli
 
-# Clean the cache for saving space
-RUN apk del build-base gcc cmake cmake-doc 
-RUN apk del curl wget bash build-base gcc
-RUN apk del cmake cmake-doc
-RUN rm -rf /var/cache/apk/*
-RUN rm libvarnam-3.2.5.tar.gz
-RUN rm -rf libvarnam-3.2.5
+# Download and compile the varnamd HTTP server.
+RUN git clone https://github.com/varnamproject/varnamd-govarnam.git
+RUN cd varnamd-govarnam && go build -o varnamd-govarnam
+
+
+
+###### Runtime stage
+FROM debian:bullseye-slim
+
+# Copy the deps and the binaries from the build stage.
+COPY --from=build /usr/local/lib/libgovarnam.so /usr/local/lib/
+COPY --from=build /usr/local/include/c-shared* /usr/local/include/
+COPY --from=build /usr/local/include/libgovarnam.h /usr/local/include/
+COPY --from=build /usr/local/lib/pkgconfig/govarnam.pc /usr/local/lib/pkgconfig/
+
+# Binaries.
+RUN mkdir -p /govarnam/ui
+COPY --from=build /app/govarnam/varnamcli /usr/local/bin/
+COPY --from=build /app/varnamd-govarnam/varnamd-govarnam /usr/local/bin/
+COPY --from=build /app/varnamd-govarnam/ui /govarnam/ui/
+
+# Setup the deps.
+ENV LD_LIBRARY_PATH=/usr/local/lib
+RUN apt-get update && apt-get install -y --no-install-recommends libc-dev sqlite3 && \
+    ldconfig /usr/local/lib && \
+    apt-get remove --purge -y libc-dev && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 8123
+
+WORKDIR /govarnam
+ENTRYPOINT ["/usr/local/bin/varnamd-govarnam"]
+CMD ["--config", "/govarnam/config.toml"]

--- a/README-docker.md
+++ b/README-docker.md
@@ -1,53 +1,58 @@
-# Docker setup for govarnamd server
+# Docker setup
 
-This repo contains the Docker setup for building a single debian-slim container with the `govarnam.so` shared lib, `varnamcli`, `varnamd-govarnam` (HTTP server) compiled with glibc.
-
+This repo contains the Docker setup for building a single debian-slim container with the `libgovarnam.so` shared lib, `varnamcli`, `varnamd-govarnam` (HTTP server) compiled with glibc.
 
 ### Running the remote image
-A pre-compiled Docker image is available on the GitHub registry. This is the simplest way to run the govarnam server (`port 8123` by default).
+
+A pre-compiled Docker image is available on the GitHub registry. This is the simplest way to run the server (`port 8123` by default).
 
 Download [config.toml](https://raw.githubusercontent.com/varnamproject/varnamd-govarnam/master/config.toml) and edit it.
 
 Run:
+
 ```bash
-docker run -e VARNAM_LEARNINGS_DIR=/govarnam/learnings -e VARNAM_VST_DIR=/govarnam/vst \
-	-v $(pwd)/config.toml:/govarnam/config.toml \
-	-v $(pwd)/data/learnings/:/govarnam/learnings/ \
-	-v $(pwd)/data/vst/:/govarnam/vst/ \
-	-v $(pwd)/data/input/:/govarnam/input/ \
+docker run -e VARNAM_LEARNINGS_DIR=/varnamd/learnings -e VARNAM_VST_DIR=/varnamd/vst \
+	-v $(pwd)/config.toml:/varnamd/config.toml \
+	-v $(pwd)/data/learnings/:/varnamd/learnings/ \
+	-v $(pwd)/data/vst/:/varnamd/vst/ \
+	-v $(pwd)/data/input/:/varnamd/input/ \
 	-p 8123:8123 \
-	--name govarnam .io/varnamproject/govarnam:latest
+	--name varnamd varnamproject.github.io/varnamproject/varnamd:latest
 ```
 
 PS: Add the `-d` flag to `docker run` to run the server in the background.
 
-
 ### Building the image locally
-- Download the [Dockerfile](https://github.com/varnamproject/varnamd-govarnam/blob/master/Dockerfile)
-- Run `docker build -t govarnam .` to build an image named `govarnam` locally.
 
+- Download the [Dockerfile](https://github.com/varnamproject/varnamd-govarnam/blob/master/Dockerfile)
+- Run `docker build -t varnamd .` to build an image named `varnamd` locally.
 
 ### Running the local image
+
 Download [config.toml](https://raw.githubusercontent.com/varnamproject/varnamd-govarnam/master/config.toml) and edit it.
 
 ```bash
-docker run -e VARNAM_LEARNINGS_DIR=/govarnam/learnings -e VARNAM_VST_DIR=/govarnam/vst \
-	-v $(pwd)/config.toml:/govarnam/config.toml \
-	-v $(pwd)/data/learnings/:/govarnam/learnings/ \
-	-v $(pwd)/data/vst/:/govarnam/vst/ \
-	-v $(pwd)/data/input/:/govarnam/input/ \
+docker run -e VARNAM_LEARNINGS_DIR=/varnamd/learnings -e VARNAM_VST_DIR=/varnamd/vst \
+	-v $(pwd)/config.toml:/varnamd/config.toml \
+	-v $(pwd)/data/learnings/:/varnamd/learnings/ \
+	-v $(pwd)/data/vst/:/varnamd/vst/ \
+	-v $(pwd)/data/input/:/varnamd/input/ \
 	-p 8123:8123 \
-	--name govarnam govarnam
+	--name varnamd varnamd
 ```
 
-## Training 
-The image comes with `varnamcli` that can be used for training. Training data is stored in the host mounted `./data/learnings` directory.
+## Importing words
 
-- Run the `govarnam` container.
+[Read this doc](https://varnamproject.com/docs/learning/) to learn more on teaching words to Varnam.
+
+The image comes with `varnamcli` that can be used for training. Varnam dictionary is stored in the host mounted `./data/learnings` directory.
+
+- Run the `varnamd` container.
 - Ensure that the necessary scheme (`-s` flag) [VST file](https://github.com/varnamproject/schemes/releases) is present in the local `./data/vst` directory.
-- Copy the training CSV file with words to `./data/input`, eg: `./data/input/yourfile.csv`
+- Copy the files needed for learning to `./data/input`, eg: `./data/input/yourfile.txt`
 
 Then run:
+
 ```bash
-docker exec govarnam varnamcli -s ml -learn-from-file /govarnam/input/yourfile.csv
+docker exec varnamd varnamcli -s ml -learn-from-file /govarnam/input/yourfile.txt
 ```

--- a/README-docker.md
+++ b/README-docker.md
@@ -1,0 +1,53 @@
+# Docker setup for govarnamd server
+
+This repo contains the Docker setup for building a single debian-slim container with the `govarnam.so` shared lib, `varnamcli`, `varnamd-govarnam` (HTTP server) compiled with glibc.
+
+
+### Running the remote image
+A pre-compiled Docker image is available on the GitHub registry. This is the simplest way to run the govarnam server (`port 8123` by default).
+
+Download [config.toml](https://raw.githubusercontent.com/varnamproject/varnamd-govarnam/master/config.toml) and edit it.
+
+Run:
+```bash
+docker run -e VARNAM_LEARNINGS_DIR=/govarnam/learnings -e VARNAM_VST_DIR=/govarnam/vst \
+	-v $(pwd)/config.toml:/govarnam/config.toml \
+	-v $(pwd)/data/learnings/:/govarnam/learnings/ \
+	-v $(pwd)/data/vst/:/govarnam/vst/ \
+	-v $(pwd)/data/input/:/govarnam/input/ \
+	-p 8123:8123 \
+	--name govarnam .io/varnamproject/govarnam:latest
+```
+
+PS: Add the `-d` flag to `docker run` to run the server in the background.
+
+
+### Building the image locally
+- Download the [Dockerfile](https://github.com/varnamproject/varnamd-govarnam/blob/master/Dockerfile)
+- Run `docker build -t govarnam .` to build an image named `govarnam` locally.
+
+
+### Running the local image
+Download [config.toml](https://raw.githubusercontent.com/varnamproject/varnamd-govarnam/master/config.toml) and edit it.
+
+```bash
+docker run -e VARNAM_LEARNINGS_DIR=/govarnam/learnings -e VARNAM_VST_DIR=/govarnam/vst \
+	-v $(pwd)/config.toml:/govarnam/config.toml \
+	-v $(pwd)/data/learnings/:/govarnam/learnings/ \
+	-v $(pwd)/data/vst/:/govarnam/vst/ \
+	-v $(pwd)/data/input/:/govarnam/input/ \
+	-p 8123:8123 \
+	--name govarnam govarnam
+```
+
+## Training 
+The image comes with `varnamcli` that can be used for training. Training data is stored in the host mounted `./data/learnings` directory.
+
+- Run the `govarnam` container.
+- Ensure that the necessary scheme (`-s` flag) [VST file](https://github.com/varnamproject/schemes/releases) is present in the local `./data/vst` directory.
+- Copy the training CSV file with words to `./data/input`, eg: `./data/input/yourfile.csv`
+
+Then run:
+```bash
+docker exec govarnam varnamcli -s ml -learn-from-file /govarnam/input/yourfile.csv
+```

--- a/README.md
+++ b/README.md
@@ -1,36 +1,15 @@
-# Varnam API Server
+# Varnam API server
 
-Varnam daemon which also acts as a HTTP server. This program powers https://varnamproject.com
+A HTTP server frontend for Varnam. This program powers https://api.varnamproject.com
 
 ## Installation
 
-You need to have [govarnam](https://github.com/varnamproject/govarnam) installed in your local system for varnamd to run.
-
-- Clone
-- Run `go get` inside cloned folder
-- Use `go run .` for starting varnamd
+- Install [Varnam](https://varnamproject.com/)
+- Clone this repo and run `make`
 
 ## Docker
-For Docker installation and usage, refer to the [Docker setup](README-docker.md).
 
-
-## Usage
-
-varnamd supports the following command line arguments:
-
-- `p` int. Run daemon in specified port
-- `max-handle-count` int. Maximum number of handles can be opened for each language
-- `host` string. Host for the varnam daemon server.
-- `ui` string. UI directory path. Put your index.html here.
-- `enable-internal-apis` boolean. Enable internal APIs
-- `enable-ssl` boolean
-- `cert-file-path` string. Certificate file path
-- `key-file-path` string.
-- `upstream` string. Provide an upstream server
-- `enable-download`. string. Comma separated language identifier for which varnamd will download words from upstream
-- `sync-interval` int.
-- `log-to-file` boolean. If true, logs will be written to a file
-- `version`
+For Docker installation and usage, refer to the [Docker README](README-docker.md).
 
 ## Hosting
 
@@ -42,7 +21,7 @@ make
 ./restart.sh
 ```
 
-Preferrably use caddy for reverse proxy:
+Preferrably use [Caddy](https://caddyserver.com/) for reverse proxy:
 
 ```ruby
 api.varnamproject.com varnam.subinsb.com {
@@ -62,10 +41,10 @@ api.varnamproject.com varnam.subinsb.com {
 ### Transliteration
 
 ```
-https://api.varnamproject.com/tl/{langCode}/{Word}
+https://api.varnamproject.com/tl/{langCode}/{word}
 ```
 
-Sample: `https://api.varnamproject.com/tl/ml/Malayalam`. Response:
+A GET request to `https://api.varnamproject.com/tl/ml/malayalam` will give the response:
 
 ```json
 {
@@ -85,8 +64,8 @@ Sample: `https://api.varnamproject.com/tl/ml/Malayalam`. Response:
     "മലയാളമാദ്ധ്യമത്തിൽ",
     "മലയാളമാദ്ധ്യമം"
   ],
-  "input": "Malayalam"
+  "input": "malayalam"
 }
 ```
 
-##### see server.go for supported APIs.
+See `server.go` for the full API list.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ You need to have [govarnam](https://github.com/varnamproject/govarnam) installed
 - Run `go get` inside cloned folder
 - Use `go run .` for starting varnamd
 
+## Docker
+For Docker installation and usage, refer to the [Docker setup](README-docker.md).
+
+
 ## Usage
 
 varnamd supports the following command line arguments:

--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@
   # download-enabled-schemes = "ml,ml-inscript"
   sync-interval = "5s"
   accounts-enabled = false
-  address = "127.0.0.1:8123"
+  address = "0.0.0.0:8123"
   [app.max-handle-count]
     default = 10
     ml = 30


### PR DESCRIPTION
This PR refactors the old Dockerfile to use a multi-stage build that builds `govarnam`, `varnamcli`, and `govarnamd` and produce a `debian:bullseye-slim` container image that can run the `govarnamd` server with a single command.

Usage instructions are in the new accompanying `README-docker.md` doc.